### PR TITLE
Add outdated warning prior to archiving repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # swift-cwinrt
+
+> [!WARNING]
+> This project contains an outdated snapshot of a subset of WinRT projections generated with [swift-winrt](https://github.com/thebrowsercompany/swift-winrt), provided for illustration purposes. To use WinRT APIs in your Swift project, we recommend using [swift-winrt](https://github.com/thebrowsercompany/swift-winrt) directly to generate your own projections.
+
 C API definition used by Swift Language bindings.
 
-This project references all metadata files uses by the various swift-* projects. The CWinRT contains the C ABI defintions for all types that can be used.
+This project references all metadata files uses by the various swift-* projects. The CWinRT contains the C ABI definitions for all types that can be used.


### PR DESCRIPTION
I will archive this repository after merging this change. Folks have been reporting issues with our pregenerated projections repos and we're neither keeping them updated nor providing ongoing support, so better avoid confusion by archiving the repos.